### PR TITLE
Updated to please Depreciation Cop

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,11 +1,9 @@
 @import 'syntax-variables';
 
-.editor-colors {
-  background-color: @syntax-background-color;
-  color: @syntax-text-color;
-}
+atom-text-editor, :host {
+    background-color: @syntax-background-color;
+    color: @syntax-text-color;
 
-.editor {
   .invisible-character, .indent-guide {
     color: fade(@syntax-invisible-character-color, 18%);
   }


### PR DESCRIPTION
Removed ".editor"  and ".editor-colors" classes in favor of new
conventions "atom-text-editor, :host {" to get Cop to shut it's trap.
Looks to display correctly, but you might want to verify for yourself.

Awesome syntax theme by the way.